### PR TITLE
Remove intro content on mobile

### DIFF
--- a/views/intro.html
+++ b/views/intro.html
@@ -13,9 +13,9 @@
       </div>
       <div class="row">
         <div class="col-xs-offset-1 col-xs-10 col-sm-offset-2 col-sm-8 col-md-offset-3 col-md-6 text-center">
-          <h1>We're On A Mission</h1>
+          <h1 class="hidden-xs">We're On A Mission</h1>
           <p>Welcome to the GA community.  Help ensure that women are always part of the public dialog... because women's voices count.</p>
-          <p>Choose how to measure inclusion:</p>
+          <p class="hidden-xs">Choose how to measure inclusion:</p>
           <a href="form">
             <div class="button btn-pad">
               <span class="larger">Count</span>


### PR DESCRIPTION
The intro page had too much content for smaller screens, resulting
in scrolling and overlapping links.  This removes some of the
non-vital content for those small screens.

Issue #13 Privacy Policy link overlap