### PR TITLE
Data correction for who talks charts

### DIFF
--- a/routes/external.js
+++ b/routes/external.js
@@ -426,8 +426,10 @@ app.post('/talkschart', function (req, res, next) {
             storeChart(pie_id, {
               "session_text": session_text,
               "hashtag": hashtag,
-              "men": dude_time,
-              "women": not_dude_time,
+              "men": men,
+              "women": women,
+              "men_time": dude_time,
+              "women_time": not_dude_time,
               "other": 0,
               "type": "whotalks",
               "pie_id": pie_id,


### PR DESCRIPTION
The who talks charts were improperly storing time spoken
as head count in the firebase data.  This meant that the
twitter cards showed the wrong stats.  Charts going
forward will now have everything in the right place.

Issue #17 "Who Talks" twitter count glitch