### PR TITLE
Change unlink to unlinksync

### DIFF
--- a/routes/external.js
+++ b/routes/external.js
@@ -544,7 +544,7 @@ app.post('/talkschart', function (req, res, next) {
             });
 
             req.session.lastCreated = pie_url;
-            fs.unlink(path.join(__dirname, '../' + card_filename));
+            fs.unlinkSync(path.join(__dirname, '../' + card_filename));
             return res.redirect('/share/' + pie_id);
           }
           return next(error);
@@ -563,7 +563,7 @@ app.post('/talkschart', function (req, res, next) {
           "pie_id": pie_id,
           "pie_url": pie_url
         });
-        fs.unlink(path.join(__dirname, '../' + card_filename));
+        fs.unlinkSync(path.join(__dirname, '../' + card_filename));
         req.session.lastCreated = pie_url;
         return res.redirect('/share/' + pie_id);
       }
@@ -835,7 +835,7 @@ app.post('/chart', function (req, res, next) {
             });
 
             req.session.lastCreated = pie_url;
-            fs.unlink(path.join(__dirname, '../' + card_filename));
+            fs.unlinkSync(path.join(__dirname, '../' + card_filename));
             return res.redirect('/share/' + pie_id);
           }
           return next(error);
@@ -853,7 +853,7 @@ app.post('/chart', function (req, res, next) {
           "pie_id": pie_id,
           "pie_url": pie_url
         });
-        fs.unlink(path.join(__dirname, '../' + card_filename));
+        fs.unlinkSync(path.join(__dirname, '../' + card_filename));
         req.session.lastCreated = pie_url;
         return res.redirect('/share/' + pie_id);
       }
@@ -1088,8 +1088,8 @@ app.post('/photo', upload.single('photo'), function (req, res, next) {
                     "pie_url": pie_url
                   });
 
-                  fs.unlink(req.file.path);
-                  fs.unlink(path.join(__dirname, '../' + card_filename));
+                  fs.unlinkSync(req.file.path);
+                  fs.unlinkSync(path.join(__dirname, '../' + card_filename));
                   req.session.lastCreated = pie_url;
                   return res.redirect('/share/' + pie_id);
                 }
@@ -1108,8 +1108,8 @@ app.post('/photo', upload.single('photo'), function (req, res, next) {
                 "pie_id": pie_id,
                 "pie_url": pie_url
               });
-              fs.unlink(req.file.path);
-              fs.unlink(path.join(__dirname, '../' + card_filename));
+              fs.unlinkSync(req.file.path);
+              fs.unlinkSync(path.join(__dirname, '../' + card_filename));
               req.session.lastCreated = pie_url;
               return res.redirect('/share/' + pie_id);
             }


### PR DESCRIPTION
At some point in the past four years Node changed unlink to require
a callback. This commit replaces unlink with the thread blocking
unlinkSync.

In reality there is no reason to block, but it would be worth doing
a more general optimization review and refactor, and sync seems less
likely to result in weird race-condition related bugs.

Issue #24 Update to Node 10.5.x