### PR TITLE
Fix whotalks form layout

### DIFF
--- a/views/whotalks/headcount.html
+++ b/views/whotalks/headcount.html
@@ -33,21 +33,21 @@
       </div>
       <form method="post" id="chart-form" action="/whotalks/chart">
         <div class="row">
-          <div class="col-xs-offset-1 col-xs-4 col-sm-offset-4 col-sm-2 text-center">
+          <div class="col-xs-6 col-sm-offset-3 col-sm-3 text-center">
               <div class="form-group {% if error.dudecount %}error{% endif %}">
-                <label for="dudecount">Dude Count:</label>
+                <label for="dudecount">Dudes:</label>
                 <input class="form-control" id="dudecount" name="dudecount" placeholder="0" {% if dudecount %}value="{{ dudecount }}"{% endif %}/>
               </div>
             </div>
-          <div class="col-xs-4 col-sm-2 text-center">
+          <div class="col-xs-6 col-sm-3 text-center">
             <div class="form-group {% if error.notdudecount %}error{% endif %}">
-              <label for="notdudecount">Not Dude Count:</label>
+              <label for="notdudecount">Not Dudes:</label>
               <input class="form-control" id="notdudecount" name="notdudecount" placeholder="0" {% if notdudecount %}value="{{ notdudecount }}"{% endif %}/>
             </div>
           </div>
         </div>
         <div class="row">
-          <div class="col-xs-offset-1 col-xs-4 col-sm-offset-3 col-sm-6 text-center">
+          <div class="col-xs-offset-0 col-xs-12 col-sm-offset-3 col-sm-6 text-center">
             <div class="form-group {% if error.session_text %} error {% endif %}">
               <label for="session_text">Title your results</label>
               <textarea class="form-control" id="session_text" name="session_text" placeholder="e.g. the name of an meeting, show, event">{% if session_text %}{{ session_text }}{% endif %}</textarea>
@@ -55,7 +55,7 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-xs-offset-1 col-xs-4 col-sm-offset-3 col-sm-6 text-center">
+          <div class="col-xs-offset-0 col-xs-12 col-sm-offset-3 col-sm-6 text-center">
             <div class="form-group {% if error.hashtag %} error {% endif %}">
               <label for="hashtag">Is there a hashtag?</label>
               <input type="text" class="form-control" name="hashtag" id="hashtag" placeholder="optional" {% if hashtag %}value="{{ hashtag }}"{% endif %}/>


### PR DESCRIPTION
There were some bootstrap mistakes in the Who Talks headcount form.
These changes make the form much nicer in all layouts, and take better
advantage of the space available on the screen.

This resolves #33.