### PR TITLE
Add back buttons to tally flow

### DIFF
--- a/views/tally/details.html
+++ b/views/tally/details.html
@@ -27,9 +27,9 @@
         </div>
       </div>
 
-      <div class="row">
-        <div class="col-xs-offset-1 col-xs-10 col-sm-offset-3 col-sm-6">
-          <form id="tally_form" method="post" role="form">
+      <form id="tally_form" method="post" role="form">
+        <div class="row">
+          <div class="col-xs-offset-1 col-xs-10 col-sm-offset-3 col-sm-6">
             <div class="form-group {% if error.session_text %} error {% endif %}">
               <label for="session_text">What are you tallying?</label>
               <textarea class="form-control" id="session_text" name="session_text" placeholder="e.g. ABC Conference or Top 100 Books XYZ Magazine">{% if session_text %}{{ session_text }}{% endif %}</textarea>
@@ -38,12 +38,17 @@
               <label for="hashtag">Hashtag</label>
               <input type="text" class="form-control" name="hashtag" id="hashtag" placeholder="optional" {% if hashtag %}value="{{ hashtag }}"{% endif %}/>
             </div>
-            <div class="form-group">
-              <input class="btn btn-default btn-lg" type="submit" value="Submit"/>
-            </div>
-          </form>
+          </div>
         </div>
-      </div>
+        <div class="row">
+          <div class="col-xs-offset-1 col-xs-5 col-sm-offset-3 col-sm-2">
+            <a href="/tally"><div class="btn btn-default btn-lg">Back</div></a>
+          </div>
+          <div class="col-xs-5 col-sm-4 text-right">
+            <input class="btn btn-default btn-lg" type="submit" value="Submit"/>
+          </div>
+        </div>
+      </form>
     </div>
 
     <div id="cityscape"></div>

--- a/views/tally/photo.html
+++ b/views/tally/photo.html
@@ -56,7 +56,10 @@
       </div>
 
       <div class="row hide-on-submit">
-        <div class="col-xs-12 text-center">
+        <div class="col-xs-6 text-center">
+          <a href="/tally/photochoice"><div class="btn btn-default btn-lg">Back</div></a>
+        </div>
+        <div class="col-xs-6 text-center">
           <form action="/tally/chart" method="post">
             <input type="submit" type="submit" value="Skip" class="btn" />
           </form>

--- a/views/tally/photo_choice.html
+++ b/views/tally/photo_choice.html
@@ -24,15 +24,23 @@
       </div>
 
       <div class="row">
-        <div class="col-xs-offset-1 col-xs-5 col-sm-offset-3 col-sm-3 text-center">
-          <a href="/tally/photo"><div class="button">Photo</div></a>
+        <div class="col-xs-offset-3 col-xs-6 col-sm-offset-3 col-sm-3 text-center">
+          <a href="/tally/photo"><div class="button btn-block">Photo</div></a>
         </div>
-        <div class="col-xs-5 col-sm-3 text-center">
+        <div class="col-xs-offset-3 col-xs-6 col-sm-offset-0 col-sm-3 text-left">
           <form method="post" id="chart-form" action="/tally/chart">
-            <input class="btn" type="submit" id="chart-submit" value="Chart"/>
+            <input class="btn btn-block" type="submit" id="chart-submit" value="Chart"/>
           </form>
         </div>
       </div>
+      <div class="row">
+        <div class="col-xs-offset-3 col-xs-6 col-sm-offset-3 col-sm-6 text-right">
+          <a href="/tally/details"><div class="btn btn-default btn-block">Back</div></a>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
     </div>
 
     <div class="footer navbar-fixed-bottom">


### PR DESCRIPTION
Users in the browser could use back buttons, but this didn't really help
for mobile users.  Now back buttons are part of the interface.

Because of the way that Who Talks works, we can't add back buttons there
just yet (we need to do a better job of storing who talks results and
re-rendering those results on refresh first).

This covers part of Issue #45