### PR TITLE
Fix broken routing link

### DIFF
--- a/routes/external.js
+++ b/routes/external.js
@@ -303,7 +303,7 @@ app.post('/whotalks/chart', function (req, res, next) {
     // This should also handled directly by javascript in the page
     // Put by posting to, the user at least doesn't see a URL change
     // if we need to, re-render it with errors
-    return res.render('whotalks-headcount.html', {
+    return res.render('whotalks/headcount.html', {
       title: 'Who Talks?',
       dudecount: men,
       notdudecount: women,


### PR DESCRIPTION
When we reorganized the code base apparently I missed this edge case as
well, which meant that users who submitted tallies with invalid data saw
an error.

There were three incidents total; this will prevent more.

This covers the first half of Issue #50