### PR TITLE
Update to node 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "private": true,
   "engines": {
-    "node": "0.10.30"
+    "node": ">=11"
   },
   "scripts": {
     "start": "node server.js"


### PR DESCRIPTION
It's possible that we shouldn't even specify a node version to begin
with; allowing heroku to just use the latest node when deploying.  We
can cross that bridge when we get there, but for now lets use 11 or
later since that's what I'm developing on.

This is related to #55