### PR TITLE
Avoid overriding version

### DIFF
--- a/routes/external.js
+++ b/routes/external.js
@@ -31,10 +31,9 @@ app.get('/', function (req, res, next) {
 
   // Is a version being passed?
   var version = parseInt(req.query.version);
-  if(!version) {
-    version = 0;
+  if(version) {
+    res.cookie('version', version);
   }
-  res.cookie('version', version);
 
   // Has the user been here before?
   var is_returning_visitor = false;


### PR DESCRIPTION
Once a version is set we don't want to override the version simply by
going back to the home page.  This should only set the version if it is
explicitly stated.