### PR TITLE
Add who talks back button

### DIFF
--- a/routes/external.js
+++ b/routes/external.js
@@ -99,8 +99,14 @@ app.get('/tally/photo', function (req, res, next) {
 });
 
 app.get('/whotalks', function (req, res, next) {
+  // It's OK to use || since falsy values *should* default to 0
+  var not_dude_time = req.session.not_dude_time || 0;
+  var dude_time = req.session.dude_time || 0;
+
   res.render('whotalks/timer.html', {
     title: 'Who Talks?',
+    dude_time: dude_time,
+    not_dude_time: not_dude_time
   });
 });
 
@@ -285,6 +291,8 @@ app.post('/tally/details', function (req, res, next) {
 app.post('/whotalks/chart', function (req, res, next) {
   var dude_time = req.session.dude_time;
   var not_dude_time = req.session.not_dude_time;
+  req.session.not_dude_time = 0;
+  req.session.dude_time = 0;
   var men = parseInt(req.body.dudecount, 10),
       women = parseInt(req.body.notdudecount, 10),
       session_text = req.body.session_text,

--- a/views/whotalks/headcount.html
+++ b/views/whotalks/headcount.html
@@ -63,11 +63,14 @@
           </div>
         </div>
         <div class="row">
-          <div class="col-xs-offset-1 col-xs-10 col-sm-offset-4 col-sm-4 text-center">
-              <div class="form-group">
-                <input class="btn btn-default btn-lg" type="submit" value="Submit"/>
-              </div>
+          <div class="col-xs-offset-1 col-xs-5 col-sm-offset-4 col-sm-2">
+            <a href="/whotalks"><div class="btn btn-default btn-lg">Back</div></a>
+          </div>
+          <div class="col-xs-5 col-sm-2 text-right">
+            <div class="form-group">
+              <input class="btn btn-default btn-lg" type="submit" value="Submit"/>
             </div>
+          </div>
         </div>
       </form>
     </div>

--- a/views/whotalks/timer.html
+++ b/views/whotalks/timer.html
@@ -52,7 +52,7 @@
         var dude = {
           time: {
             minutes: 0,
-            seconds: 0,
+            seconds: {{dude_time}},
             hours: 0
           },
           active: false
@@ -60,7 +60,7 @@
         var not_dude = {
           time: {
             minutes: 0,
-            seconds: 0,
+            seconds: {{not_dude_time}},
             hours: 0
           },
           active: false
@@ -82,15 +82,14 @@
             return num;
           }
         }
-        function add(tally, display_sel, input_sel) {
-          tally.seconds++;
+        function setTime(tally, display_sel, input_sel) {
           if (tally.seconds >= 60) {
-            tally.minutes++;
-            tally.seconds = 0;
+            tally.minutes += Math.floor(tally.seconds / 60);
+            tally.seconds = tally.seconds % 60;
           }
           if (tally.minutes >= 60) {
-            tally.hours++;
-            tally.minutes = 0;
+            tally.hours += Math.floor(tally.minutes / 60);
+            tally.minutes = tally.minutes % 60;
           }
           if (tally.hours !== 0) {
             $(display_sel).html(num_pad(tally.hours) + ':' + num_pad(tally.minutes) + ':' + num_pad(tally.seconds));
@@ -104,8 +103,10 @@
 
           var d_tot = (dude.time.hours * 3600) + (dude.time.minutes * 60) + dude.time.seconds;
           var l_tot = (not_dude.time.hours * 3600) + (not_dude.time.minutes * 60) + not_dude.time.seconds;
-          var pct = parseInt(d_tot / (d_tot + l_tot) * 100, 10);
-          $ans.html('<span id="pct">' + pct + '</span>% men');
+          if(d_tot + l_tot > 0) {
+            var pct = parseInt(d_tot / (d_tot + l_tot) * 100, 10);
+            $ans.html('<span id="pct">' + pct + '</span>% men');
+          }
         }
         $dude.click(function() {
           $dude.toggleClass('pressed');
@@ -125,7 +126,8 @@
               clearInterval(not_dude_t);
             }
             dude_t = setInterval(function() {
-              add(dude.time, '#dude-display', '#dude-input');
+              dude.time.seconds++;
+              setTime(dude.time, '#dude-display', '#dude-input');
             }, 1000);
           }
         });
@@ -147,7 +149,8 @@
               clearInterval(dude_t);
             }
             not_dude_t = setInterval(function() {
-              add(not_dude.time, '#not-dude-display', '#not-dude-input');
+              not_dude.time.seconds++;
+              setTime(not_dude.time, '#not-dude-display', '#not-dude-input');
             }, 1000);
           }
         });
@@ -158,6 +161,10 @@
             $not_dude.trigger('click');
           }
         });
+
+
+        setTime(not_dude.time, '#not-dude-display', '#not-dude-input');
+        setTime(dude.time, '#dude-display', '#dude-input');
       });
     </script>
   </body>


### PR DESCRIPTION
The who talks back button was more complex because of the way who talks
sets the timers.  This commit adds that button in, though we should put
some urgency on the ability to edit the timers manually in order to
cover the use case where a user actually WANTS to start from a clean
slate.

Issue #45