### PR TITLE
Remove download button versioning

### DIFF
--- a/views/core/share.html
+++ b/views/core/share.html
@@ -29,11 +29,9 @@
         <div class="col-xs-offset-1 col-xs-10 col-sm-offset-2 col-sm-4 col-md-offset-2 col-md-4 text-center">
           <a class="social" href="mailto:?cc=gina@genderavenger.com&subject=GA%20Tally&body=I thought you might want to see this gender breakdown: http://app.genderavenger.com/share/{{ pie_id }}" title="Share by Email"><div class="button">Share by Email</div></a>
         </div>
-      {% if version > 20190402 %}
         <div class="col-xs-offset-1 col-xs-10 col-sm-offset-0 col-sm-4 col-md-4 text-center">
           <a class="social" href="{{pie}}" download><div class="button">Download</div></a>
         </div>
-      {% endif %}
       {% if report_is_new %}
         <div class="col-xs-offset-1 col-xs-10 col-sm-offset-4 col-sm-4 col-md-offset-4 col-md-4 text-center">
           <form action="/anonymous/{{ pie_id }}" method="post"><button type="submit" class="btn">Submit Anonymously</button></form>


### PR DESCRIPTION
We added a version for the download button so folks would have time to
update to the most recent app.  Enough time has passed that we can
remove that version check (and therefore make it so the download button
appears by default on the web version as well)

Resolves #73