### PR TITLE
Remove race from ballotmania

### DIFF
--- a/routes/external.js
+++ b/routes/external.js
@@ -156,9 +156,7 @@ app.post('/ballotmania/ballot', function (req, res, next) {
   var file_id = uuid.v4();
   var chart_filename = "assets/chartgen/" + file_id + "_chart.png";
   var card_filename = "assets/chartgen/" + file_id + "_card.png";
-  req.session.whitewomen = parseInt(req.body.whiteWomen, 10);
-  req.session.womenofcolor = parseInt(req.body.womenOfColor, 10);
-  req.session.women = req.session.whitewomen + req.session.womenofcolor;
+  req.session.women = parseInt(req.body.women, 10);
   req.session.men = parseInt(req.body.men, 10);
   req.session.nonbinary = parseInt(req.body.nonbinary, 10);
   req.session.hashtag = "#ballotmania";
@@ -172,11 +170,7 @@ app.post('/ballotmania/ballot', function (req, res, next) {
   var chart_filename = "assets/chartgen/" + file_id + "_chart.png";
   var card_filename = "assets/chartgen/" + file_id + "_card.png";
 
-  if(req.session.womenofcolor > req.session.women) {
-    req.session.women += req.session.womenofcolor;
-  }
   var proportionWomen = req.session.women / (req.session.women + req.session.men + req.session.nonbinary);
-  var proportionWomenOfColor = req.session.womenofcolor / (req.session.women + req.session.men + req.session.nonbinary);
   var proportionNonbinary = req.session.nonbinary / (req.session.women + req.session.men + req.session.nonbinary);
 
   var image_parameters = [];
@@ -211,17 +205,6 @@ app.post('/ballotmania/ballot', function (req, res, next) {
       '-fill', '#edce63',
       '-stroke', '#edce63',
       '-draw', 'path \'M 450,500 L 450,700 A 200,200 0 ' + ((degrees > 270)?1:0) + ',1 ' + x + ',' + y + ' Z\''
-    );
-  }
-  if(proportionWomenOfColor > 0) {
-    var degrees = (proportionWomenOfColor * 360 + 90);
-    var radians = degrees * Math.PI / 180;
-    var x = 450 + 200 * Math.cos(radians);
-    var y = 500 + 200 * Math.sin(radians);
-    image_parameters.push(
-      '-tile', 'assets/stripes.gif',
-      '-draw', 'path \'M 450,500 L 450,700 A 200,200 0 ' + ((degrees > 270)?1:0) + ',1 ' + x + ',' + y + ' Z\'',
-      '+tile'
     );
   }
 
@@ -266,28 +249,6 @@ app.post('/ballotmania/ballot', function (req, res, next) {
       '-annotate', '+25+670', req.session.nonbinary + ((req.session.nonbinary == 1)?" Nonbinary Person":" Nonbinary Persons"));
   }
 
-  if(req.session.womenofcolor == 0) {
-    image_parameters.push(
-      '-stroke', '#000000',
-      '-fill', '#d87111',
-      '-draw', 'rectangle 65,665 360,707');
-
-    image_parameters.push(
-      '-gravity', 'NorthWest',
-      '-stroke', '#ffffff',
-      '-fill', '#ffffff',
-      '-font', 'Arial',
-      '-pointsize', '30',
-      '-annotate', '+75+670', "No Women of Color!");
-  } else {
-    image_parameters.push(
-      '-gravity', 'NorthWest',
-      '-stroke', '#d87111',
-      '-fill', '#d87111',
-      '-font', 'Arial',
-      '-pointsize', '30',
-      '-annotate', '+75+670', req.session.womenofcolor + ((req.session.womenofcolor == 1)?" Woman of Color":" Women of Color"));
-  }
   image_parameters.push(
     '-gravity', 'NorthEast',
     '-stroke', '#FF0000',

--- a/routes/external.js
+++ b/routes/external.js
@@ -179,7 +179,7 @@ app.post('/ballotmania/ballot', function (req, res, next) {
   );
 
   image_parameters.push('-page', '+0+0','assets/base_background.png');
-  image_parameters.push('-page', '+0+0','assets/city_background_ballotmania.png');
+  image_parameters.push('-page', '+0+10','assets/city_background_ballotmania.png');
   image_parameters.push('-page', '+0+130','assets/horizontal_bar.png');
 
   // Draw the chart
@@ -241,12 +241,12 @@ app.post('/ballotmania/ballot', function (req, res, next) {
 
   if(req.session.nonbinary > 0) {
     image_parameters.push(
-      '-gravity', 'NorthEast',
+      '-gravity', 'Center',
       '-stroke', '#9E84CB',
       '-fill', '#9E84CB',
       '-font', 'Arial',
       '-pointsize', '30',
-      '-annotate', '+25+670', req.session.nonbinary + ((req.session.nonbinary == 1)?" Nonbinary Person":" Nonbinary Persons"));
+      '-annotate', '+0+280', req.session.nonbinary + ((req.session.nonbinary == 1)?" Nonbinary Person":" Nonbinary Persons"));
   }
 
   image_parameters.push(

--- a/views/ballotmania/ballot.html
+++ b/views/ballotmania/ballot.html
@@ -63,10 +63,7 @@
                   <div class="col-xs-12 text-center">
                     <div class="row">
                       <div class="col-xs-12">
-                        <div class="button ballot-button woman-of-color-button" id="woman-of-color-{{index}}">Woman of color</div>
-                      </div>
-                      <div class="col-xs-12">
-                        <div class="button ballot-button white-woman-button" id="white-woman-{{index}}">White woman</div>
+                        <div class="button ballot-button woman-button" id="woman-{{index}}">Woman</div>
                       </div>
                       <div class="col-xs-12">
                         <div class="button ballot-button man-button" id="man-{{index}}">Man</div>
@@ -106,8 +103,7 @@
             </div>
             <div class="col-xs-5 col-sm-3 text-left">
               <input type="hidden" name="men" value="0" id="men" />
-              <input type="hidden" name="whiteWomen" value="0" id="white-women" />
-              <input type="hidden" name="womenOfColor" value="0" id="women-of-color" />
+              <input type="hidden" name="women" value="0" id="women" />
               <input type="hidden" name="nonbinary" value="0" id="nonbinary" />
               <input class="btn btn-default btn-lg" type="submit" value="Submit"/>
             </div>
@@ -121,8 +117,7 @@
         var candidateCount = $(".candidate").length;
         var selectionCount =
           $("#men").val() +
-          $("#white-women").val() +
-          $("#women-of-color").val() +
+          $("#women").val() +
           $("#nonbinary").val();
 
         if(selectionCount < candidateCount) {
@@ -134,8 +129,7 @@
 
       function resetButtonsByIndex(index) {
         $("#man-" + index).removeClass("pressed");
-        $("#white-woman-" + index).removeClass("pressed");
-        $("#woman-of-color-" + index).removeClass("pressed");
+        $("#woman-" + index).removeClass("pressed");
         $("#nonbinary-" + index).removeClass("pressed");
       }
 
@@ -149,13 +143,8 @@
             return total + 1;
           return total;
         }, 0)
-        var whiteWomanCount = selections.reduce(function(total, selection) {
-          if (selection === "ww")
-            return total + 1;
-          return total;
-        }, 0)
-        var womanOfColorCount = selections.reduce(function(total, selection) {
-          if (selection === "woc")
+        var womanCount = selections.reduce(function(total, selection) {
+          if (selection === "w")
             return total + 1;
           return total;
         }, 0)
@@ -166,15 +155,13 @@
         }, 0)
 
         $("#men").val(manCount);
-        $("#white-women").val(whiteWomanCount);
-        $("#women-of-color").val(womanOfColorCount);
+        $("#women").val(womanCount);
         $("#nonbinary").val(nonbinaryCount);
       }
 
       $(function() {
         var manButtons = $(".man-button");
-        var wwButtons = $(".white-woman-button");
-        var wocButtons = $(".woman-of-color-button");
+        var womanButtons = $(".woman-button");
         var nonbinaryButtons = $(".nonbinary-button");
         var selections = [];
 
@@ -187,22 +174,13 @@
           selections[index] = 'm';
           setCounts(selections);
         })
-        wwButtons.click(function() {
+        womanButtons.click(function() {
           var $this = $(this);
           var id = $this.attr("id");
-          var index = parseInt(id.slice(12), 10);
+          var index = parseInt(id.slice(6), 10);
           resetButtonsByIndex(index);
           activateButton($this);
-          selections[index] = 'ww';
-          setCounts(selections);
-        })
-        wocButtons.click(function() {
-          var $this = $(this);
-          var id = $this.attr("id");
-          var index = parseInt(id.slice(15), 10);
-          resetButtonsByIndex(index);
-          activateButton($this);
-          selections[index] = 'woc';
+          selections[index] = 'w';
           setCounts(selections);
         })
         nonbinaryButtons.click(function() {


### PR DESCRIPTION
Race was often impossible to tally on ballotmania since not every candidate has a registered picture (and many are obscure enough that there is no reliable way to look up a picture online).

This removes race from the ballotmania tally, and also adjusts the output of non binary person count to prevent accidental visual conflation with the men count now that we no longer render a section for women of color.

Resolves #80 